### PR TITLE
[POC-AIRFLOW]: Send airflow DAG metrics to StatsD

### DIFF
--- a/airflow_statsd_poc/configs/airflow.cfg
+++ b/airflow_statsd_poc/configs/airflow.cfg
@@ -1,0 +1,9 @@
+[core]
+executor = LocalExecutor
+sql_alchemy_conn = postgresql+psycopg2://airflow:airflow@postgres/airflow
+
+[metrics]
+statsd_on = True
+statsd_host = statsd-exporter
+statsd_port = 9125
+statsd_prefix = airflow

--- a/airflow_statsd_poc/configs/grafana-cluster-dashboard.json
+++ b/airflow_statsd_poc/configs/grafana-cluster-dashboard.json
@@ -1,0 +1,1620 @@
+{
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            }
+        ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": 2,
+    "iteration": 1612802652229,
+    "links": [],
+    "panels": [
+        {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 43,
+            "panels": [],
+            "title": "Scheduler",
+            "type": "row"
+        },
+        {
+            "cacheTimeout": null,
+            "datasource": null,
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 4,
+                "w": 8,
+                "x": 0,
+                "y": 1
+            },
+            "id": 17,
+            "interval": null,
+            "links": [],
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "mean"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.3.5",
+            "targets": [
+                {
+                    "expr": "af_agg_scheduler_heartbeat{airflow_id=\"$airflow_id\"}",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Scheduler heartbeat",
+            "type": "stat"
+        },
+        {
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "links": [],
+                    "mappings": [],
+                    "noValue": "0",
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 4,
+                "w": 3,
+                "x": 8,
+                "y": 1
+            },
+            "id": 4,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "mean"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.3.5",
+            "targets": [
+                {
+                    "expr": "af_agg_dagbag_size{airflow_id=\"$airflow_id\"}",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Dagbag size",
+            "type": "stat"
+        },
+        {
+            "datasource": null,
+            "description": "Seconds taken to scan and import all DAG files once",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "s"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 4,
+                "w": 4,
+                "x": 11,
+                "y": 1
+            },
+            "id": 14,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "mean"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.3.5",
+            "targets": [
+                {
+                    "expr": "af_agg_dag_processing_total_parse_time{airflow_id=\"$airflow_id\"}",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "DAG processing total parse time",
+            "type": "stat"
+        },
+        {
+            "datasource": null,
+            "description": "Number of errors from trying to parse DAG files",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "links": [],
+                    "mappings": [],
+                    "noValue": "0",
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 4,
+                "w": 4,
+                "x": 15,
+                "y": 1
+            },
+            "id": 6,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "mean"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.3.5",
+            "targets": [
+                {
+                    "expr": "af_agg_dag_processing_import_errors{airflow_id=\"$airflow_id\"}",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Dagbag import errors",
+            "type": "stat"
+        },
+        {
+            "datasource": null,
+            "description": "Zombie tasks killed",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "mappings": [],
+                    "noValue": "0",
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 4,
+                "w": 5,
+                "x": 19,
+                "y": 1
+            },
+            "id": 29,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.3.5",
+            "targets": [
+                {
+                    "expr": "af_agg_zombies_killed{airflow_id=\"$airflow_id\"}",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Zombies killed",
+            "type": "stat"
+        },
+        {
+            "datasource": null,
+            "description": "Overall task instances successes",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "mappings": [],
+                    "noValue": "0",
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 4,
+                "x": 0,
+                "y": 5
+            },
+            "id": 35,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.3.5",
+            "targets": [
+                {
+                    "expr": "af_agg_ti_successes{airflow_id=\"$airflow_id\"}",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Total successful tasks",
+            "type": "stat"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 4,
+                "y": 5
+            },
+            "hiddenSeries": false,
+            "id": 39,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.5",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "rate(af_agg_operator_successes{airflow_id=\"$airflow_id\"}[1m]) * 60",
+                    "interval": "",
+                    "legendFormat": "{{operator_name}}",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Operator success rate per minuite",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "description": "Total failures of given operator",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 12,
+                "y": 5
+            },
+            "hiddenSeries": false,
+            "id": 41,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.5",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "rate(af_agg_operator_failures{airflow_id=\"$airflow_id\"}[1m]) * 60",
+                    "interval": "",
+                    "legendFormat": "{{operator_name}}",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Operator failure rate per minute",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": "ops",
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "mappings": [],
+                    "noValue": "0",
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 4,
+                "x": 20,
+                "y": 5
+            },
+            "id": 37,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.3.5",
+            "targets": [
+                {
+                    "expr": "af_agg_ti_failures{airflow_id=\"$airflow_id\"}",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Total failed tasks",
+            "type": "stat"
+        },
+        {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 11
+            },
+            "id": 45,
+            "panels": [],
+            "title": "Executor Pool",
+            "type": "row"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 6,
+                "w": 16,
+                "x": 0,
+                "y": 12
+            },
+            "hiddenSeries": false,
+            "id": 56,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.5",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "rate(af_agg_job_start{airflow_id=\"$airflow_id\"}[1m]) * 60",
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "{{job_name}}",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Jobs started per minute",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "mappings": [],
+                    "noValue": "0",
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 4,
+                "x": 16,
+                "y": 12
+            },
+            "id": 10,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.3.5",
+            "targets": [
+                {
+                    "expr": "af_agg_executor_open_slots{airflow_id=\"$airflow_id\"}",
+                    "instant": false,
+                    "interval": "1",
+                    "intervalFactor": 1,
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Executor open slots",
+            "type": "stat"
+        },
+        {
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "mappings": [],
+                    "noValue": "0",
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 4,
+                "x": 20,
+                "y": 12
+            },
+            "id": 53,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.3.5",
+            "targets": [
+                {
+                    "expr": "af_agg_executor_queued_tasks{airflow_id=\"$airflow_id\"}",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Executor queued tasks",
+            "type": "stat"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 6,
+                "w": 16,
+                "x": 0,
+                "y": 18
+            },
+            "hiddenSeries": false,
+            "id": 21,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.5",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "rate(af_agg_job_end{airflow_id=\"$airflow_id\"}[1m]) * 60",
+                    "interval": "",
+                    "legendFormat": "{{job_name}}",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Jobs ended per minute",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "datasource": null,
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "mappings": [],
+                    "noValue": "0",
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 4,
+                "x": 16,
+                "y": 18
+            },
+            "id": 55,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.3.5",
+            "targets": [
+                {
+                    "expr": "af_agg_executor_running_tasks{airflow_id=\"$airflow_id\"}",
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Executor running tasks",
+            "type": "stat"
+        },
+        {
+            "collapsed": true,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 24
+            },
+            "id": 47,
+            "panels": [],
+            "title": "DAG stats",
+            "type": "row"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "description": "Seconds taken for a DagRun to reach success state",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {
+                        "align": null,
+                        "filterable": false
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    },
+                    "unit": "ms"
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 25
+            },
+            "hiddenSeries": false,
+            "id": 25,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.5",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "af_agg_dagrun_duration_success{airflow_id=\"$airflow_id\"} * 1000",
+                    "format": "time_series",
+                    "interval": "",
+                    "legendFormat": "{{dag_id}} p{{quantile}}",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Success DAG run duration",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ms",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "description": "Seconds taken for a DagRun to reach failed state",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "mappings": [],
+                    "noValue": "0",
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    },
+                    "unit": "s"
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 33
+            },
+            "hiddenSeries": false,
+            "id": 49,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.5",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "af_agg_dagrun_duration_failed{airflow_id=\"$airflow_id\"} * 1000",
+                    "interval": "",
+                    "legendFormat": "{{dag_id}} p{{quantile}}",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Failed DAG run duration",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "description": "Sum of seconds taken to finish a tasks aggregated by DAG",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            }
+                        ]
+                    },
+                    "unit": "s"
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 40
+            },
+            "hiddenSeries": false,
+            "id": 51,
+            "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.5",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "sum by (dag_id, quantile) (af_agg_dag_task_duration{airflow_id=\"$airflow_id\"}) * 1000",
+                    "format": "time_series",
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "{{dag_id}} p{{quantile}}",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "DAG run duration",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "s",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "description": "Seconds taken to check DAG dependencies",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {
+                        "align": null,
+                        "filterable": false
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "ms"
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 46
+            },
+            "hiddenSeries": false,
+            "id": 19,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.5",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "af_agg_dagrun_dependency_check{airflow_id=\"$airflow_id\"} * 1000",
+                    "interval": "",
+                    "legendFormat": "{{dag_id}} p{{quantile}}",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "DAG run dependency check time",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "ms",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": null,
+            "description": "Seconds of delay between the scheduled DagRun start date and the actual DagRun start date",
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {},
+                    "unit": "ms"
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 53
+            },
+            "hiddenSeries": false,
+            "id": 27,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.3.5",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "expr": "af_agg_dagrun_schedule_delay{airflow_id=\"$airflow_id\"} * 1000",
+                    "interval": "",
+                    "legendFormat": "{{dag_id}} p{{quantile}}",
+                    "refId": "A"
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "DAG run schedule delay",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": "0",
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        }
+    ],
+    "refresh": "5s",
+    "schemaVersion": 26,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [
+            {
+                "allValue": null,
+                "current": {
+                    "selected": false,
+                    "text": "airflow",
+                    "value": "airflow"
+                },
+                "datasource": "Prometheus",
+                "definition": "label_values(airflow_id)",
+                "error": null,
+                "hide": 0,
+                "includeAll": false,
+                "label": "Airflow Instance Id",
+                "multi": false,
+                "name": "airflow_id",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "airflow",
+                        "value": "airflow"
+                    }
+                ],
+                "query": "label_values(airflow_id)",
+                "refresh": 0,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            }
+        ]
+    },
+    "time": {
+        "from": "now-1h",
+        "to": "now"
+    },
+    "timepicker": {
+        "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+        ]
+    },
+    "timezone": "",
+    "title": "Airflow cluster dashboard",
+    "uid": "lFXqBGxWk",
+    "version": 8
+}

--- a/airflow_statsd_poc/configs/prometheus.yaml
+++ b/airflow_statsd_poc/configs/prometheus.yaml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval:     5s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: airflow
+    scheme: http
+    metrics_path: metrics
+    static_configs:
+      - targets: ['host.docker.internal:9102']
+        labels:
+          airflow_id: 'airflow'

--- a/airflow_statsd_poc/configs/statsd.yaml
+++ b/airflow_statsd_poc/configs/statsd.yaml
@@ -1,0 +1,241 @@
+mappings:
+  - match: "*.ti_failures"
+    match_metric_type: counter
+    name: "af_agg_ti_failures"
+    labels:
+      airflow_id: "$1"
+  - match: "*.ti_successes"
+    match_metric_type: counter
+    name: "af_agg_ti_successes"
+    labels:
+      airflow_id: "$1"
+  - match: "*.zombies_killed"
+    match_metric_type: counter
+    name: "af_agg_zombies_killed"
+    labels:
+      airflow_id: "$1"
+  - match: "*.scheduler_heartbeat"
+    match_metric_type: counter
+    name: "af_agg_scheduler_heartbeat"
+    labels:
+      airflow_id: "$1"
+  - match: "*.dag_processing.processes"
+    match_metric_type: counter
+    name: "af_agg_dag_processing_processes"
+    labels:
+      airflow_id: "$1"
+  - match: "*.scheduler.tasks.killed_externally"
+    match_metric_type: counter
+    name: "af_agg_scheduler_tasks_killed_externally"
+    labels:
+      airflow_id: "$1"
+  - match: "*.scheduler.tasks.running"
+    match_metric_type: counter
+    name: "af_agg_scheduler_tasks_running"
+    labels:
+      airflow_id: "$1"
+  - match: "*.scheduler.tasks.starving"
+    match_metric_type: counter
+    name: "af_agg_scheduler_tasks_starving"
+    labels:
+      airflow_id: "$1"
+  - match: "*.scheduler.orphaned_tasks.cleared"
+    match_metric_type: counter
+    name: "af_agg_scheduler_orphaned_tasks_cleared"
+    labels:
+      airflow_id: "$1"
+  - match: "*.scheduler.orphaned_tasks.adopted"
+    match_metric_type: counter
+    name: "af_agg_scheduler_orphaned_tasks_adopted"
+    labels:
+      airflow_id: "$1"
+  - match: "*.scheduler.critical_section_busy"
+    match_metric_type: counter
+    name: "af_agg_scheduler_critical_section_busy"
+    labels:
+      airflow_id: "$1"
+  - match: "*.sla_email_notification_failure"
+    match_metric_type: counter
+    name: "af_agg_sla_email_notification_failure"
+    labels:
+      airflow_id: "$1"
+  - match: "*.ti.start.*.*"
+    match_metric_type: counter
+    name: "af_agg_ti_start"
+    labels:
+      airflow_id: "$1"
+      dag_id: "$2"
+      task_id: "$3"
+  - match: "*.ti.finish.*.*.*"
+    match_metric_type: counter
+    name: "af_agg_ti_finish"
+    labels:
+      airflow_id: "$1"
+      dag_id: "$2"
+      task_id: "$3"
+      state: "$4"
+  - match: "*.dag.callback_exceptions"
+    match_metric_type: counter
+    name: "af_agg_dag_callback_exceptions"
+    labels:
+      airflow_id: "$1"
+  - match: "*.celery.task_timeout_error"
+    match_metric_type: counter
+    name: "af_agg_celery_task_timeout_error"
+    labels:
+      airflow_id: "$1"
+
+  # === Gauges ===
+  - match: "*.dagbag_size"
+    match_metric_type: gauge
+    name: "af_agg_dagbag_size"
+    labels:
+      airflow_id: "$1"
+  - match: "*.dag_processing.import_errors"
+    match_metric_type: gauge
+    name: "af_agg_dag_processing_import_errors"
+    labels:
+      airflow_id: "$1"
+  - match: "*.dag_processing.total_parse_time"
+    match_metric_type: gauge
+    name: "af_agg_dag_processing_total_parse_time"
+    labels:
+      airflow_id: "$1"
+  - match: "*.dag_processing.last_runtime.*"
+    match_metric_type: gauge
+    name: "af_agg_dag_processing_last_runtime"
+    labels:
+      airflow_id: "$1"
+      dag_file: "$2"
+  - match: "*.dag_processing.last_run.seconds_ago.*"
+    match_metric_type: gauge
+    name: "af_agg_dag_processing_last_run_seconds"
+    labels:
+      airflow_id: "$1"
+      dag_file: "$2"
+  - match: "*.dag_processing.processor_timeouts"
+    match_metric_type: gauge
+    name: "af_agg_dag_processing_processor_timeouts"
+    labels:
+      airflow_id: "$1"
+  - match: "*.executor.open_slots"
+    match_metric_type: gauge
+    name: "af_agg_executor_open_slots"
+    labels:
+      airflow_id: "$1"
+  - match: "*.executor.queued_tasks"
+    match_metric_type: gauge
+    name: "af_agg_executor_queued_tasks"
+    labels:
+      airflow_id: "$1"
+  - match: "*.executor.running_tasks"
+    match_metric_type: gauge
+    name: "af_agg_executor_running_tasks"
+    labels:
+      airflow_id: "$1"
+  - match: "*.pool.open_slots.*"
+    match_metric_type: gauge
+    name: "af_agg_pool_open_slots"
+    labels:
+      airflow_id: "$1"
+      pool_name: "$2"
+  - match: "*.pool.queued_slots.*"
+    match_metric_type: gauge
+    name: "af_agg_pool_queued_slots"
+    labels:
+      airflow_id: "$1"
+      pool_name: "$2"
+  - match: "*.pool.running_slots.*"
+    match_metric_type: gauge
+    name: "af_agg_pool_running_slots"
+    labels:
+      airflow_id: "$1"
+      pool_name: "$2"
+  - match: "*.pool.starving_tasks.*"
+    match_metric_type: gauge
+    name: "af_agg_pool_starving_tasks"
+    labels:
+      airflow_id: "$1"
+      pool_name: "$2"
+  - match: "*.smart_sensor_operator.poked_tasks"
+    match_metric_type: gauge
+    name: "af_agg_smart_sensor_operator_poked_tasks"
+    labels:
+      airflow_id: "$1"
+  - match: "*.smart_sensor_operator.poked_success"
+    match_metric_type: gauge
+    name: "af_agg_smart_sensor_operator_poked_success"
+    labels:
+      airflow_id: "$1"
+  - match: "*.smart_sensor_operator.poked_exception"
+    match_metric_type: gauge
+    name: "af_agg_smart_sensor_operator_poked_exception"
+    labels:
+      airflow_id: "$1"
+  - match: "*.smart_sensor_operator.exception_failures"
+    match_metric_type: gauge
+    name: "af_agg_smart_sensor_operator_exception_failures"
+    labels:
+      airflow_id: "$1"
+  - match: "*.smart_sensor_operator.infra_failures"
+    match_metric_type: gauge
+    name: "af_agg_smart_sensor_operator_infra_failures"
+    labels:
+      airflow_id: "$1"
+
+  # === Timers ===
+  - match: "*.dagrun.dependency-check.*"
+    match_metric_type: observer
+    name: "af_agg_dagrun_dependency_check"
+    labels:
+      airflow_id: "$1"
+      dag_id: "$2"
+  - match: "*.dag.*.*.duration"
+    match_metric_type: observer
+    name: "af_agg_dag_task_duration"
+    labels:
+      airflow_id: "$1"
+      dag_id: "$2"
+      task_id: "$3"
+  - match: "*.dag_processing.last_duration.*"
+    match_metric_type: observer
+    name: "af_agg_dag_processing_duration"
+    labels:
+      airflow_id: "$1"
+      dag_file: "$2"
+  - match: "*.dagrun.duration.success.*"
+    match_metric_type: observer
+    name: "af_agg_dagrun_duration_success"
+    labels:
+      airflow_id: "$1"
+      dag_id: "$2"
+  - match: "*.dagrun.duration.failed.*"
+    match_metric_type: observer
+    name: "af_agg_dagrun_duration_failed"
+    labels:
+      airflow_id: "$1"
+      dag_id: "$2"
+  - match: "*.dagrun.schedule_delay.*"
+    match_metric_type: observer
+    name: "af_agg_dagrun_schedule_delay"
+    labels:
+      airflow_id: "$1"
+      dag_id: "$2"
+  - match: "*.scheduler.critical_section_duration"
+    match_metric_type: observer
+    name: "af_agg_scheduler_critical_section_duration"
+    labels:
+      airflow_id: "$1"
+  - match: "*.dagrun.*.first_task_scheduling_delay"
+    match_metric_type: observer
+    name: "af_agg_dagrun_first_task_scheduling_delay"
+    labels:
+      airflow_id: "$1"
+      dag_id: "$2"
+  - match: "*.dag.*.*.my_counter"
+    match_metric_type: counter
+    name: "my_custom_task_counter"
+    labels:
+      airflow_id: "$1"
+      dag_id: "$2"
+      task_id: "$3"

--- a/airflow_statsd_poc/dags/sample_statsd_dag.py
+++ b/airflow_statsd_poc/dags/sample_statsd_dag.py
@@ -1,0 +1,53 @@
+from airflow.operators.python import PythonOperator
+from airflow.utils.dates import days_ago
+from airflow.configuration import conf
+from statsd import StatsClient
+from airflow import DAG
+import time
+
+STATSD_HOST = conf.get("metrics", "statsd_host")
+STATSD_PORT = conf.get("metrics", "statsd_port")
+STATSD_PREFIX = conf.get("metrics", "statsd_prefix")
+
+
+def task(run_time, **context):
+    metric_name = f'dag.{context["dag"].dag_id}.{context["task"].task_id}.my_counter'
+    client = StatsClient(host=STATSD_HOST, port=STATSD_PORT, prefix=STATSD_PREFIX)
+    for i in range(0, run_time):
+        time.sleep(1)
+        client.incr(metric_name)
+        print(i)
+
+
+default_args = {
+    'owner': 'airflow',
+    'start_date': days_ago(5)
+}
+
+dag = DAG(
+    'statsd_dag',
+    default_args=default_args,
+    description='',
+    schedule_interval="*/2 * * * *",
+    catchup=False
+)
+
+my_task_1 = PythonOperator(
+    task_id='my_task',
+    python_callable=task,
+    op_args=[5],
+    dag=dag,
+    provide_context=True
+)
+
+my_task_2 = PythonOperator(
+    task_id='my_task_2',
+    python_callable=task,
+    op_args=[2],
+    dag=dag,
+    provide_context=True
+)
+
+my_task_1 >> my_task_2
+
+

--- a/airflow_statsd_poc/docker-compose.yaml
+++ b/airflow_statsd_poc/docker-compose.yaml
@@ -1,0 +1,111 @@
+x-airflow-common:
+  image: 'apache/airflow:2.8.3-python3.8'
+  volumes: &ref_0
+    - './dags:/opt/airflow/dags'
+    - './logs:/opt/airflow/logs'
+    - './configs/airflow.cfg:/opt/airflow/airflow.cfg'
+  user: '${AIRFLOW_UID:-50000}:${AIRFLOW_GID:-50000}'
+  depends_on: &ref_1
+    postgres:
+      condition: service_healthy
+services:
+  airflow-init:
+    image: 'apache/airflow:2.8.3-python3.8'
+    volumes: *ref_0
+    user: '${AIRFLOW_UID:-50000}:${AIRFLOW_GID:-50000}'
+    depends_on: *ref_1
+    entrypoint: '/bin/bash -c "/bin/bash -c \"$${@}\""'
+    command: |
+      /bin/bash -c "
+        airflow db init
+        airflow db upgrade
+        airflow users create -r Admin -u admin -e airflow@airflow.com -f admin -l user -p airflow
+      "
+  postgres:
+    image: 'postgres:13'
+    environment:
+      POSTGRES_USER: airflow
+      POSTGRES_PASSWORD: airflow
+      POSTGRES_DATABASE: airflow
+    volumes:
+      - 'postgres-db-volume:/var/lib/postgressql/data'
+    healthcheck:
+      test:
+        - CMD
+        - pg_isready
+        - '-U'
+        - airflow
+      interval: 10s
+      retries: 5
+      start_period: 5s
+    restart: always
+  airflow-scheduler:
+    image: 'apache/airflow:2.8.3-python3.8'
+    volumes: *ref_0
+    user: '${AIRFLOW_UID:-50000}:${AIRFLOW_GID:-50000}'
+    depends_on: *ref_1
+    command: scheduler
+    restart: always
+  airflow-webserver:
+    image: 'apache/airflow:2.8.3-python3.8'
+    volumes: *ref_0
+    user: '${AIRFLOW_UID:-50000}:${AIRFLOW_GID:-50000}'
+    depends_on: *ref_1
+    command: webserver
+    ports:
+      - '8081:8080'
+    healthcheck:
+      test:
+        - CMD
+        - curl
+        - '--fail'
+        - 'http://localhost:8080/health'
+      interval: 10s
+      timeout: 10s
+      retries: 5
+    restart: always
+  statsd-exporter:
+    image: 'prom/statsd-exporter:v0.21.0'
+    volumes:
+      - './configs/statsd.yaml:/home/statsd-mapping-configs.yaml'
+    entrypoint:
+      - /bin/sh
+      - '-c'
+      - '--'
+    command:
+      - >-
+        statsd_exporter --log.level debug
+        --statsd.mapping-config=/home/statsd-mapping-configs.yaml
+    ports:
+      - '9102:9102'
+      - '9125:9125'
+    restart: always
+  prometheus:
+    image: 'prom/prometheus:v2.26.0'
+    volumes:
+      - './configs/prometheus.yaml:/etc/prometheus/prometheus.yaml'
+      - 'prometheus_data:/prometheus'
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yaml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+      - '--web.console.templates=/usr/share/prometheus/consoles'
+    ports:
+      - '9092:9090'
+    restart: always
+  grafana:
+    image: 'grafana/grafana:6.7.2'
+    container_name: grafana
+    volumes:
+      - 'grafana_data:/var/lib/grafana'
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=grafana
+      - GF_USERS_ALLOW_SIGN_UP=false
+    restart: always
+    ports:
+      - '3000:3000'
+volumes:
+  prometheus_data: null
+  grafana_data: null
+  postgres-db-volume: null


### PR DESCRIPTION
###  Context
----
The aim of this PR is to generate metrics from airflow DAGs, Send them to observability frameworks (`StatsD`). Map these metrics on `prometheus` localhost. Register `prometheus` as a datasource on `grafana` dashboard and view the airflow metrics in a form of `graphs` and `charts`.

### Tasks
----

- Created docker-compose file incorporating services for `Airflow`, `StatsD`, `Prometheus` and `Grafana`.
- Configured `Airflow` to emit `DAG metrics` such as **task run** success/failure and **DAG run** success/failure time using StatsD.
- Integrated `Prometheus` to collect and store emitted metrics from `Airflow` via `StatsD`. This enables persistent storage and querying of Airflow metrics.
- Developed a `Grafana` dashboard leveraging `Prometheus` as the datasource. This dashboard visualizes `Airflow DAG` metrics, providing users with a comprehensive view of `DAG` performance through graphs and charts.

### Future Improvements
---

- Explore additional metrics and visualizations to provide deeper insights into Airflow DAG execution.
- Implement alerts based on metric thresholds to enable proactive monitoring and issue resolution.

### Notes
---
- This PR lays the foundation for improved observability and performance monitoring within the Airflow ecosystem. Feedback and suggestions for further enhancements are highly encouraged.
- Results Attached : [Here](https://github.com/rjs-7399/poc_work/pull/1#issuecomment-2007939730)